### PR TITLE
[기능] 카카오 로그인 화면 구현

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { PageContainer } from '../components/Layout';
 import LoginCircle from '../assets/images/LoginCircle.png';
 import KakaoLogo from '../assets/images/KakaoLogin.png';
+import axios from 'axios';
 
 const LoginContainer = styled(PageContainer)`
   display: flex;
@@ -44,29 +45,21 @@ function Login() {
 
   const getToken = async (authCode, provider) => {
     try {
-      const response = await fetch(`http://mood9.shop/api/${provider}/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          code: authCode,
-        }),
+      const response = await axios.post(`https://mood9.shop/api/${provider}/token`, {
+        code: authCode,
       });
-
-      const data = await response.json();
       
-      if (response.ok) {
-        localStorage.setItem('accessToken', data.accessToken);
+      console.log('서버 응답:', response.data);
+      
+      if (response.status === 200) {
+        localStorage.setItem('accessToken', response.data.data.accessToken);
         navigate('/home');
-      } else {
-        console.error('로그인 오류:', {
-          statusCode: data.statusCode,
-          message: data.message
-        });
       }
     } catch (error) {
-      console.error('로그인 중 오류 발생:', error);
+      console.error('에러 상태 코드:', error.response?.status);
+      console.error('에러 데이터:', error.response?.data);
+      console.error('에러 헤더:', error.response?.headers);
+      console.error('전체 에러 객체:', error);
     }
   };
 


### PR DESCRIPTION
## 변경 사항

### 로그인 페이지 구현
   - 카카오 소셜 로그인 기능 추가
   - 로그인 화면 UI 구현 (로고 이미지, 카카오 로그인 버튼)
   - 라우팅 설정 업데이트
     - /login 경로 추가
   - 새로운 이미지 asset 추가
     - LoginCircle.png: 로그인 페이지 메인 로고 이미지
     - KakaoLogin.png: 카카오 로그인 버튼 이미지
- 카카오 OAuth 인증 기능 구현
  - 카카오 인증 요청 및 콜백 처리
  - axios를 사용한 토큰 발급 API 연동
  - 로그인 성공 시 토큰 저장 및 홈 화면 이동

## 주요 기능
1. 카카오 로그인 버튼 클릭 시 카카오 인증 페이지로 리다이렉트
2. 인증 완료 후 authorization code 발급
3. 백엔드 서버와 통신하여 access token 발급
4. localStorage를 통한 토큰 관리

## 테스트 방법
1. 맨 마지막에 /login 입력 ( 아직 splash.jsx에서 토큰 존재를 확인하는 로직과 navigate('/home')으로만 설정되어 있어서 @yuunhae  님께서 고쳐주시면 splah에서 바로 넘어갈 수 있음 )
![image](https://github.com/user-attachments/assets/35373b18-3694-4322-a59c-6bcaf321bb83)
2. 카카오 로그인 하기
3. 홈 화면으로 이동됨

## 토큰 사용하는 법
```
const [reviews, setReviews] = useState([]);

  useEffect(() => {
    const fetchReviews = async () => {
      try {
        const response = await axios.get('https://mood9.shop/api/reviews', {
          headers: {
            Authorization: `Bearer ${localStorage.getItem('accessToken')}`
          }
        });
        setReviews(response.data.data.reviews);
        console.log(response.data.data.reviews);
      } catch (error) {
        console.error('리뷰 데이터 조회 실패:', error);
      }
    };

    fetchReviews();
  }, []);
```
- 로컬스토리지에 저장된 token을 가져와서 header에 넣어 요청을 보내면 됩니다!
